### PR TITLE
refactor(vefaas): Update environment variable names for consistency

### DIFF
--- a/mcp/server/mcp_server_vefaas_function/README.md
+++ b/mcp/server/mcp_server_vefaas_function/README.md
@@ -16,13 +16,13 @@ This project provides a MCP server for managing veFaaS (Volc Engine Function as 
 ## Prerequisites
 
 - Python 3.12+
-- Access to Volc Engine (ACCESS_KEY_ID and ACCESS_KEY_SECRET)
+- Access to Volc Engine (VOLC_ACCESSKEY and VOLC_SECRETKEY)
 
 ## Getting started
 
 - Configure
 
-Please set the value for envirable variable ACCESS_KEY_ID and ACCESS_KEY_SECRET in [](./mcp.json)
+Please set the value for envirable variable VOLC_ACCESSKEY and VOLC_SECRETKEY in [](./mcp.json)
 
 ```json
 {
@@ -35,8 +35,8 @@ Please set the value for envirable variable ACCESS_KEY_ID and ACCESS_KEY_SECRET 
         "mcp-server-vefaas-function"
       ],
       "env": {
-        "ACCESS_KEY_ID": "xxx",
-        "ACCESS_KEY_SECRET": "xxx"
+        "VOLC_ACCESSKEY": "xxx",
+        "VOLC_SECRETKEY": "xxx"
       }
     }
   }

--- a/mcp/server/mcp_server_vefaas_function/mcp.json
+++ b/mcp/server/mcp_server_vefaas_function/mcp.json
@@ -4,12 +4,12 @@
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://code.byted.org/machinelearning/mcp#subdirectory=server/mcp_server_vefaas_function",
+        "git+https://github.com/volcengine/ai-app-lab#subdirectory=mcp/server/mcp_server_vefaas_function",
         "vefaas-function"
       ],
       "env": {
-        "ACCESS_KEY_ID": "xxx",
-        "ACCESS_KEY_SECRET": "xxx"
+        "VOLC_ACCESSKEY": "xxx",
+        "VOLC_SECRETKEY": "xxx"
       }
     }
   }

--- a/mcp/server/mcp_server_vefaas_function/pyproject.toml
+++ b/mcp/server/mcp_server_vefaas_function/pyproject.toml
@@ -5,19 +5,8 @@ description = "MCP server for managing veFaaS (Volc Engine Function as a Service
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "pydantic",
-    "pydantic-core",
-    "fastapi",
-    "uvicorn",
     "mcp",
-    "langchain-core",
-    "langchain-openai",
-    "langgraph",
-    "langchain-mcp-adapters",
     "volcengine-python-sdk==1.0.128",
-    "sniffio",
-    "anyio",
-    "starlette",
 ]
 
 [project.scripts]

--- a/mcp/server/mcp_server_vefaas_function/vefaas_server.py
+++ b/mcp/server/mcp_server_vefaas_function/vefaas_server.py
@@ -155,13 +155,13 @@ def generate_random_name(prefix="mcp", length=8):
 
 def init_client(region: str = None):
     """Set up VeFaaS configuration with credentials from environment variables"""
-    if "ACCESS_KEY_ID" not in os.environ:
-        raise ValueError("ACCESS_KEY_ID environment variable is not set")
-    if "ACCESS_KEY_SECRET" not in os.environ:
-        raise ValueError("ACCESS_KEY_SECRET environment variable is not set")
+    if "VOLC_ACCESSKEY" not in os.environ:
+        raise ValueError("VOLC_ACCESSKEY environment variable is not set")
+    if "VOLC_SECRETKEY" not in os.environ:
+        raise ValueError("VOLC_SECRETKEY environment variable is not set")
 
-    ak = os.environ["ACCESS_KEY_ID"]
-    sk = os.environ["ACCESS_KEY_SECRET"]
+    ak = os.environ["VOLC_ACCESSKEY"]
+    sk = os.environ["VOLC_SECRETKEY"]
 
     configuration = volcenginesdkcore.Configuration()
     configuration.ak = ak

--- a/mcp/server/mcp_server_vefaas_function/vefaas_server_test.py
+++ b/mcp/server/mcp_server_vefaas_function/vefaas_server_test.py
@@ -6,11 +6,11 @@ from vefaas_server import does_function_exist
 class TestVeFaaSServerIntegration(unittest.TestCase):
     def setUp(self):
         # Check if credentials are available
-        self.ak = os.environ.get("ACCESS_KEY_ID")
-        self.sk = os.environ.get("ACCESS_KEY_SECRET")
+        self.ak = os.environ.get("VOLC_ACCESSKEY")
+        self.sk = os.environ.get("VOLC_SECRETKEY")
         if not self.ak or not self.sk:
             self.assertFalse(
-                "ACCESS_KEY_ID or ACCESS_KEY_SECRET environment variables not set"
+                "VOLC_ACCESSKEY or VOLC_SECRETKEY environment variables not set"
             )
 
     def test_does_function_exist_with_real_credentials(self):


### PR DESCRIPTION
The environment variables for accessing Volc Engine have been renamed from ACCESS_KEY_ID and ACCESS_KEY_SECRET to VOLC_ACCESSKEY and VOLC_SECRETKEY respectively. This change ensures consistency with Volc Engine's naming conventions and improves clarity in the codebase. The update affects the README, configuration files, and the server implementation.

Co-authored-by: @Ssskrilex