### PR TITLE
feat(arkitect): update readme

### DIFF
--- a/arkitect/README.md
+++ b/arkitect/README.md
@@ -61,11 +61,11 @@
    pip install arkitect --index-url https://pypi.org/simple
    ```
 
-2. 登录[方舟控制台](https://console.volcengine.com/ark/region:ark+cn-beijing/endpoint?projectName=default)，创建一个推理接入点（Endpoint），推荐使用Doubao-pro-32k [参考文档](https://www.volcengine.com/docs/82379/1399008#_2-%E5%88%9B%E5%BB%BA%E5%9C%A8%E7%BA%BF%E6%8E%A8%E7%90%86%E6%8E%A5%E5%85%A5%E7%82%B9%EF%BC%88endpoint%EF%BC%89)
+2. 登录[方舟控制台](https://console.volcengine.com/ark/region:ark+cn-beijing/endpoint?projectName=default)，点击开通管理，推荐使用Doubao-pro-32k [参考文档](https://www.volcengine.com/docs/82379/1399008#_2-%E5%88%9B%E5%BB%BA%E5%9C%A8%E7%BA%BF%E6%8E%A8%E7%90%86%E6%8E%A5%E5%85%A5%E7%82%B9%EF%BC%88endpoint%EF%BC%89)
 
 3. 登录[方舟控制台](https://console.volcengine.com/ark/region:ark+cn-beijing/endpoint?projectName=default)，创建一个 API KEY [参考文档](https://www.volcengine.com/docs/82379/1399008#_1-%E8%8E%B7%E5%8F%96%E5%B9%B6%E9%85%8D%E7%BD%AE-api-key)
 
-4. 创建`main.py`，修改文件中的 endpoint_id 为您新创建的推理接入点 ID。
+4. 创建`main.py`，修改文件中的 model 部分，示例中为 `doubao-1.5-pro-32k-250115` 你可以替换成其它的模型 ID。(Model ID 获取方式, 在火山方舟->开通管理 开通指定大模型之后, 点进详情页即可获取到)
 
 ```python
 """
@@ -194,7 +194,7 @@ curl --location 'http://localhost:8080/api/v3/bots/chat/completions' \
 
 3. 登录[方舟控制台](https://console.volcengine.com/ark/region:ark+cn-beijing/endpoint?projectName=default)，创建一个 API KEY [参考文档](https://www.volcengine.com/docs/82379/1399008#_1-%E8%8E%B7%E5%8F%96%E5%B9%B6%E9%85%8D%E7%BD%AE-api-key)
 
-4. 创建`main.py`，修改文件中的 endpoint_id 为您新创建的推理接入点 ID。
+4. 创建`main.py`，修改文件中的 model 部分，示例中为 `deepseek-v3-241226` 你可以替换成其它的模型 ID。(Model ID 获取方式, 在火山方舟->开通管理 开通指定大模型之后, 点进详情页即可获取到)
 
 ```python
 """

--- a/arkitect/README_en.md
+++ b/arkitect/README_en.md
@@ -53,7 +53,7 @@
 
 2. **Create an Inference** **Endpoint**: Log in to the [Ark Console](https://console.volcengine.com/ark/region:ark+cn-beijing/endpoint?projectName=default) and create an endpoint. 
 3. **Generate an API Key:** Follow the [API Key guide](https://www.volcengine.com/docs/82379/1399008#_1-获取并配置-api-key). 
-4. **Create** **`main.py`**: Replace `endpoint_id` with your newly created endpoint ID.
+4. **Create main.py**: Replace the model part in the file. The example uses `doubao-1.5-pro-32k-250115`, which you can replace with other model ID.
 
 ```Python
 import os
@@ -136,7 +136,7 @@ pip install arkitect --index-url https://pypi.org/simple
 
 2. **Create an Inference** **Endpoint**: Log in to the [Ark Console](https://console.volcengine.com/ark/region:ark+cn-beijing/endpoint?projectName=default) and create an endpoint OR using a function-call model (e.g., Doubao-pro-32k-functioncall-241028). (For BytePlus users, please refer to [ModelArk Console](https://console.byteplus.com/ark/region:ark-stg+ap-southeast-1/endpoint?projectName=default) to create an endpoint.)
 3. **Generate an API Key:** Follow the [API Key guide](https://www.volcengine.com/docs/82379/1399008#_1-获取并配置-api-key). (For BytePlus users, please refer to the  [Obtaining API Key](https://docs.byteplus.com/en/docs/ModelArk/1399008#_1-obtaining-and-configuring-api-key))
-4. **Create** **`main.py`**: Replace `endpoint_id` with your newly created endpoint ID.
+4. **Create main.py**: Replace the model part in the file. The example uses `doubao-1.5-pro-32k-250115`, which you can replace with other model ID.
 
 ```Python
 """


### PR DESCRIPTION
最近在从 v0.1 升级到 v0.2  的过程中, 发现官方 sdk 的使用稍有变化，实际测试下来已经不需要创建 `endpoint_id` 了，发现官方文档没有更新，因此在升级完 sdk 版本之后提 pr 更新下官方 sdk 的文档。

