### PR TITLE
Fix: incompatible version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1522,6 +1522,8 @@ files = [
     {file = "orjson-3.10.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:960db0e31c4e52fa0fc3ecbaea5b2d3b58f379e32a95ae6b0ebeaa25b93dfd34"},
     {file = "orjson-3.10.6-cp312-none-win32.whl", hash = "sha256:a6ea7afb5b30b2317e0bee03c8d34c8181bc5a36f2afd4d0952f378972c4efd5"},
     {file = "orjson-3.10.6-cp312-none-win_amd64.whl", hash = "sha256:874ce88264b7e655dde4aeaacdc8fd772a7962faadfb41abe63e2a4861abc3dc"},
+    {file = "orjson-3.10.6-cp313-none-win32.whl", hash = "sha256:efdf2c5cde290ae6b83095f03119bdc00303d7a03b42b16c54517baa3c4ca3d0"},
+    {file = "orjson-3.10.6-cp313-none-win_amd64.whl", hash = "sha256:8e190fe7888e2e4392f52cafb9626113ba135ef53aacc65cd13109eb9746c43e"},
     {file = "orjson-3.10.6-cp38-cp38-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:66680eae4c4e7fc193d91cfc1353ad6d01b4801ae9b5314f17e11ba55e934183"},
     {file = "orjson-3.10.6-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:caff75b425db5ef8e8f23af93c80f072f97b4fb3afd4af44482905c9f588da28"},
     {file = "orjson-3.10.6-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3722fddb821b6036fd2a3c814f6bd9b57a89dc6337b9924ecd614ebce3271394"},
@@ -2862,4 +2864,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8.1,<3.12.0"
-content-hash = "55d8125f9d753596520416e0c670bcf3c11e6dde714933f6f03a24a74faafb10"
+content-hash = "1fb458e15a5f067a116b75891376363aeec1579ed16a6816426d3c48926a248c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ packages = [{ include = "arkitect" }]
 version = "0.1.5"
 description = ""
 authors = ["wangsen.0914 <wangsen.0914@bytedance.com>"]
-readme = "README.md"
+readme = "README.md" 
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.12.0"
@@ -18,7 +18,7 @@ opentelemetry-exporter-otlp = ">=1.22.0,<2.0.0"
 jinja2 = "^3.1.2"
 structlog = ">=23.1.0,<25.0.0"
 opentelemetry-sdk = ">=1.22.0,<2.0.0"
-volcengine-python-sdk = ">=1.0.117"
+volcengine-python-sdk = ">=1.0.117,<3.0.0"
 httpx = ">=0.27.0"
 pytz = "2020.5"
 tenacity = "8.3.0"


### PR DESCRIPTION
lock volc-python-sdk version below 3.0