### PR TITLE
fix(chat2cartoon): use extra_headers arg in websockets.connect

### DIFF
--- a/demohouse/chat2cartoon/backend/app/clients/tts.py
+++ b/demohouse/chat2cartoon/backend/app/clients/tts.py
@@ -271,7 +271,7 @@ class TTSClient:
     ):
         headers = self.build_http_header(self.conn_id, self.log_id)
         INFO("with logID: %s , header: %s", self.log_id, headers)
-        self.conn = await websockets.connect(TTS_BASE_URL, additional_headers=headers)
+        self.conn = await websockets.connect(TTS_BASE_URL, extra_headers=headers)
         self.params = params
         INFO("Dial server with LogID: %s", self.log_id)
         # Create a new message with type MsgTypeFullClient and flag MsgTypeFlagWithEvent


### PR DESCRIPTION
in websockets 13.1, the correct arg should be extra_headers