### PR TITLE
fix: restrict mobile agent server to localhost

### DIFF
--- a/demohouse/mobile-use/mobile_agent/README.md
+++ b/demohouse/mobile-use/mobile_agent/README.md
@@ -59,6 +59,9 @@ cp .env.example .env
 uv run main.py
 ```
 
+The HTTP server is intended for local use only. `main.py` always binds to
+`127.0.0.1`, even if `UVICORN_SERVER_HOST` is configured differently.
+
 ### Configuration
 
 ```bash
@@ -91,4 +94,3 @@ Mobile device operations supported through Mobile Use MCP:
 | `mobile:close_app` | Close application | `package_name` |
 | `mobile:launch_app` | Launch application | `package_name` |
 | `mobile:list_apps` | List installed applications | - |
-

--- a/demohouse/mobile-use/mobile_agent/README_zh.md
+++ b/demohouse/mobile-use/mobile_agent/README_zh.md
@@ -59,6 +59,9 @@ cp .env.example .env
 uv run main.py
 ```
 
+该 HTTP 服务仅预期在本机使用。`main.py` 会始终监听 `127.0.0.1`，
+即使配置了其他 `UVICORN_SERVER_HOST` 也不会对外网卡暴露。
+
 ### 配置说明
 
 ```bash

--- a/demohouse/mobile-use/mobile_agent/app.py
+++ b/demohouse/mobile-use/mobile_agent/app.py
@@ -13,10 +13,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 # 导入配置
-from mobile_agent.middleware.middleware import (
-    ResponseMiddleware,
-    AuthMiddleware,
-)
+from mobile_agent.middleware.middleware import ResponseMiddleware
 from mobile_agent.config.settings import settings
 from mobile_agent.routers.base import register_routers
 
@@ -31,7 +28,8 @@ app = FastAPI(
 # Enable CORS
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=[],
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -39,8 +37,6 @@ app.add_middleware(
 
 # 添加响应格式中间件
 app.add_middleware(ResponseMiddleware)
-# 添加账户鉴权中间件
-app.add_middleware(AuthMiddleware)
 
 # 注册所有路由
 register_routers(app)

--- a/demohouse/mobile-use/mobile_agent/main.py
+++ b/demohouse/mobile-use/mobile_agent/main.py
@@ -21,17 +21,25 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+LOCAL_HOST = "127.0.0.1"
+
 
 def main():
     # 打印配置信息
     logger.info(f"Starting {settings.app_name} v{settings.app_version}")
     logger.info(f"Environment: {settings.env}")
+    if settings.server.host != LOCAL_HOST:
+        logger.warning(
+            "Configured host %s is ignored; local server listens on %s only",
+            settings.server.host,
+            LOCAL_HOST,
+        )
     logger.info(
-        f"Server config: host={settings.server.host}, port={settings.server.port}"
+        f"Server config: host={LOCAL_HOST}, port={settings.server.port}"
     )
 
     # 启动服务器
-    uvicorn.run("app:app", host=settings.server.host, port=settings.server.port)
+    uvicorn.run("app:app", host=LOCAL_HOST, port=settings.server.port)
 
 
 if __name__ == "__main__":

--- a/demohouse/mobile-use/mobile_agent/mobile_agent/config/settings.py
+++ b/demohouse/mobile-use/mobile_agent/mobile_agent/config/settings.py
@@ -38,7 +38,7 @@ MOBILE_USE_MCP_NAME = "mobile"
 class ServerConfig(BaseModel):
     """服务器配置"""
 
-    host: str = "0.0.0.0"
+    host: str = "127.0.0.1"
     port: int = 8000
 
 
@@ -78,7 +78,7 @@ class Settings(BaseSettings):
     app_version: str = "0.1.0"
     # uvicorn
     server: ServerConfig = ServerConfig(
-        host=os.environ.get("UVICORN_SERVER_HOST", "0.0.0.0"),
+        host=os.environ.get("UVICORN_SERVER_HOST", "127.0.0.1"),
         port=int(os.environ.get("UVICORN_SERVER_PORT", 8000)),
     )
     # 环境配置

--- a/demohouse/mobile-use/mobile_agent/mobile_agent/middleware/middleware.py
+++ b/demohouse/mobile-use/mobile_agent/mobile_agent/middleware/middleware.py
@@ -24,30 +24,6 @@ from mobile_agent.exception.api import APIException
 logger = logging.getLogger(__name__)
 
 
-class AuthMiddleware(BaseHTTPMiddleware):
-    """账户鉴权中间件"""
-
-    async def dispatch(self, request: Request, call_next):
-        # 获取账户ID
-        account_id = request.headers.get("X-Account-Id")
-        faas_instance_name = request.headers.get("x-faas-instance-name")
-        logger.info(f"账户ID: {account_id}，FaaS实例名称: {faas_instance_name}")
-
-        # 检查是否提供了账户ID
-        if not account_id:
-            return wrap_error_response(
-                code=401,
-                message="账户ID不存在，鉴权失败",
-            )
-
-        # 将账户ID绑定到请求状态中
-        request.state.account_id = account_id
-
-        # 继续处理请求
-        response = await call_next(request)
-        return response
-
-
 class ResponseMiddleware(BaseHTTPMiddleware):
     """
     响应中间件，统一处理成功和失败的返回格式

--- a/demohouse/mobile-use/mobile_agent/mobile_agent/routers/agent.py
+++ b/demohouse/mobile-use/mobile_agent/mobile_agent/routers/agent.py
@@ -11,7 +11,7 @@
 
 import asyncio
 import uuid
-from fastapi import APIRouter, Request
+from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
 import logging
 from mobile_agent.exception.sse import SSEException
@@ -22,7 +22,7 @@ from mobile_agent.agent.graph.sse_output import (
 from mobile_agent.agent.infra.message_web import SummaryMessageData
 from mobile_agent.agent.mobile_use_agent import MobileUseAgent
 from mobile_agent.middleware.middleware import APIException
-from mobile_agent.service.session.manager import session_manager
+from mobile_agent.service.session.manager import LOCAL_ACCOUNT_ID, session_manager
 import langgraph.errors
 from pydantic import BaseModel, Field
 
@@ -94,7 +94,7 @@ class AgentStreamRequest(BaseModel):
 
 
 @router.post("/stream")
-async def agent_stream(request: Request, body: AgentStreamRequest):
+async def agent_stream(body: AgentStreamRequest):
     """
     流式响应API
 
@@ -105,7 +105,7 @@ async def agent_stream(request: Request, body: AgentStreamRequest):
         StreamingResponse: 事件流响应
     """
     try:
-        account_id = request.state.account_id
+        account_id = LOCAL_ACCOUNT_ID
         user_prompt = body.message
         thread_id = body.thread_id
         is_stream = body.is_stream
@@ -150,7 +150,6 @@ async def agent_stream(request: Request, body: AgentStreamRequest):
                 "Connection": "keep-alive",
                 "X-Accel-Buffering": "no",
                 "Content-Type": "text/event-stream",
-                "Access-Control-Allow-Origin": "*",
             },
         )
 
@@ -170,11 +169,11 @@ class CancelAgentRequest(BaseModel):
 
 
 @router.post("/cancel")
-async def cancel_agent(request: Request, body: CancelAgentRequest):
+async def cancel_agent(body: CancelAgentRequest):
     """
     取消智能代理
     """
-    account_id = request.state.account_id
+    account_id = LOCAL_ACCOUNT_ID
     thread_id = body.thread_id
 
     if not thread_id:

--- a/demohouse/mobile-use/mobile_agent/mobile_agent/routers/session.py
+++ b/demohouse/mobile-use/mobile_agent/mobile_agent/routers/session.py
@@ -13,12 +13,11 @@
 会话相关路由
 """
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter
 import logging
 import uuid
-from mobile_agent.config.settings import get_settings
 from mobile_agent.middleware.middleware import APIException
-from mobile_agent.service.session.manager import session_manager
+from mobile_agent.service.session.manager import LOCAL_ACCOUNT_ID, session_manager
 from pydantic import BaseModel, Field
 from typing import Optional
 
@@ -37,8 +36,8 @@ class CreateSessionRequest(BaseModel):
 
 
 @router.post("/create")
-async def create_session(request: Request, body: CreateSessionRequest):
-    account_id = request.state.account_id
+async def create_session(body: CreateSessionRequest):
+    account_id = LOCAL_ACCOUNT_ID
     thread_id = body.thread_id
     product_id = body.product_id
     pod_id = body.pod_id
@@ -49,7 +48,12 @@ async def create_session(request: Request, body: CreateSessionRequest):
             product_id=product_id,
         )
 
-        logger.info(f"更新会话状态: {thread_id} {response_json}")
+        logger.info(
+            "更新会话状态: thread_id=%s, product_id=%s, pod_id=%s",
+            thread_id,
+            product_id,
+            pod_id,
+        )
         session = session_manager.update_thread_state(
             thread_id,
             device_info=response_json["device_info"],
@@ -61,7 +65,12 @@ async def create_session(request: Request, body: CreateSessionRequest):
             device_id=pod_id,
             product_id=product_id,
         )
-        logger.info(f"创建会话成功: {thread_id} {response_json}")
+        logger.info(
+            "创建会话成功: thread_id=%s, product_id=%s, pod_id=%s",
+            thread_id,
+            product_id,
+            pod_id,
+        )
         session = session_manager.create_thread(
             account_id,
             thread_id,
@@ -87,11 +96,11 @@ class ResetSessionRequest(BaseModel):
 
 
 @router.post("/reset")
-async def reset_session(request: Request, body: ResetSessionRequest):
+async def reset_session(body: ResetSessionRequest):
     """
     重置会话，保持同一个 pod 但切换到新的 chat_thread_id
     """
-    account_id = request.state.account_id
+    account_id = LOCAL_ACCOUNT_ID
     thread_id = body.thread_id
 
     if not thread_id:

--- a/demohouse/mobile-use/mobile_agent/mobile_agent/service/session/manager.py
+++ b/demohouse/mobile-use/mobile_agent/mobile_agent/service/session/manager.py
@@ -20,6 +20,8 @@ from mobile_agent.service.pod.manager import pod_manager
 
 logger = logging.getLogger(__name__)
 
+LOCAL_ACCOUNT_ID = "local"
+
 
 class StsToken(BaseModel):
     AccessKeyID: str


### PR DESCRIPTION
## Summary
- remove spoofable `X-Account-Id` middleware for the local-only mobile agent service
- force the server to bind to `127.0.0.1` and document the local-only deployment model
- restrict CORS to localhost origins and avoid logging STS credential payloads

## Verification
- `python -m py_compile main.py mobile_agent/middleware/middleware.py mobile_agent/routers/session.py mobile_agent/routers/agent.py mobile_agent/config/settings.py mobile_agent/service/session/manager.py`
- `git diff --check`
- searched for residual `AuthMiddleware`, `X-Account-Id`, `request.state.account_id`, `0.0.0.0`, and wildcard SSE CORS headers