### PR TITLE
feat(cua): prevent press key command injection

### DIFF
--- a/demohouse/computer_use/tool_server/README.md
+++ b/demohouse/computer_use/tool_server/README.md
@@ -120,7 +120,7 @@ The tool server supports a simple API-key based authentication and TLS:
 
 ```toml
 # Shared API key. Clients must send it via the `X-API-Key` (or `Authorization`) header.
-# Leave empty to disable authentication.
+# Required. Set AUTH_KEY or inject a non-empty value through deployment configuration.
 auth_key = "your-secret-api-key-here"
 
 [plugins]

--- a/demohouse/computer_use/tool_server/config.toml
+++ b/demohouse/computer_use/tool_server/config.toml
@@ -1,5 +1,6 @@
 port = 8102
 display = ":5"
+# Required at startup. Set a non-empty value through AUTH_KEY or deployment configuration.
 auth_key = ""
 
 [log]

--- a/demohouse/computer_use/tool_server/main.py
+++ b/demohouse/computer_use/tool_server/main.py
@@ -28,10 +28,16 @@ app.add_middleware(AuthMiddleware)
 configure_logging()
 
 
+def validate_security_settings(settings) -> None:
+    if not settings.auth_key:
+        raise RuntimeError("auth_key must be configured before starting tool_server")
+
+
 def main():
     import uvicorn
 
     settings = get_settings()
+    validate_security_settings(settings)
 
     uvicorn_kwargs = {
         "host": "0.0.0.0",

--- a/demohouse/computer_use/tool_server/middleware/auth.py
+++ b/demohouse/computer_use/tool_server/middleware/auth.py
@@ -26,9 +26,6 @@ class AuthMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
 
     async def dispatch(self, request: Request, call_next) -> Response:
-        if get_settings().auth_key == "":
-            return await call_next(request)
-
         auth_header = request.headers.get("X-API-Key")
         if not auth_header:
             auth_header = request.headers.get("Authorization")

--- a/demohouse/computer_use/tool_server/tests/test_presskey_security.py
+++ b/demohouse/computer_use/tool_server/tests/test_presskey_security.py
@@ -1,0 +1,85 @@
+import asyncio
+import sys
+import unittest
+from unittest.mock import AsyncMock, Mock, patch
+from pathlib import Path
+
+from fastapi import HTTPException
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.computer import PressKeyRequest
+from tools.computer_xdotool import XDOComputerTool, normalize_key
+
+
+class NormalizeKeyTests(unittest.TestCase):
+    def test_maps_existing_named_key_combination(self):
+        self.assertEqual(normalize_key("ctrl c"), "Control_L+c")
+        self.assertEqual(normalize_key("alt+tab"), "Alt_L+Tab")
+
+    def test_accepts_single_alphanumeric_key(self):
+        self.assertEqual(normalize_key("a"), "a")
+        self.assertEqual(normalize_key("7"), "7")
+
+    def test_rejects_shell_metacharacters(self):
+        with self.assertRaises(HTTPException) as context:
+            normalize_key("a;id>/tmp/poc")
+
+        self.assertEqual(context.exception.status_code, 400)
+
+
+class PressKeyExecutionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_uses_exec_with_key_as_a_separate_argument(self):
+        process = type("Process", (), {"communicate": AsyncMock(return_value=(b"", b""))})()
+        tool = XDOComputerTool(display=":99")
+
+        with patch(
+            "tools.computer_xdotool.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=process),
+        ) as create_process:
+            result = await tool.press_key(PressKeyRequest(key="ctrl c"))
+
+        create_process.assert_awaited_once()
+        args, kwargs = create_process.call_args
+        self.assertEqual(args, ("xdotool", "key", "--", "Control_L+c"))
+        self.assertEqual(kwargs["env"]["DISPLAY"], ":99")
+        self.assertEqual(result.output, "")
+        self.assertEqual(result.error, "")
+
+    async def test_kills_subprocess_when_press_key_times_out(self):
+        process = type(
+            "Process",
+            (),
+            {
+                "communicate": AsyncMock(side_effect=asyncio.TimeoutError),
+                "kill": Mock(),
+            },
+        )()
+        tool = XDOComputerTool(display=":99")
+
+        with patch(
+            "tools.computer_xdotool.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=process),
+        ):
+            with self.assertRaises(TimeoutError):
+                await tool.press_key(PressKeyRequest(key="enter"))
+
+        process.kill.assert_called_once()
+
+    async def test_returns_error_when_xdotool_is_unavailable(self):
+        tool = XDOComputerTool(display=":99")
+
+        with patch(
+            "tools.computer_xdotool.asyncio.create_subprocess_exec",
+            new=AsyncMock(side_effect=FileNotFoundError("xdotool not found")),
+        ):
+            result = await tool.press_key(PressKeyRequest(key="enter"))
+
+        self.assertEqual(result.output, "")
+        self.assertIn("xdotool not found", result.error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/demohouse/computer_use/tool_server/tests/test_startup_security.py
+++ b/demohouse/computer_use/tool_server/tests/test_startup_security.py
@@ -1,0 +1,23 @@
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from main import validate_security_settings
+
+
+class StartupSecurityTests(unittest.TestCase):
+    def test_rejects_empty_auth_key(self):
+        with self.assertRaisesRegex(RuntimeError, "auth_key"):
+            validate_security_settings(SimpleNamespace(auth_key=""))
+
+    def test_accepts_configured_auth_key(self):
+        validate_security_settings(SimpleNamespace(auth_key="configured-secret"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/demohouse/computer_use/tool_server/tools/computer_xdotool.py
+++ b/demohouse/computer_use/tool_server/tools/computer_xdotool.py
@@ -11,6 +11,7 @@
 
 import base64
 import asyncio
+import os
 from typing import Optional
 from pathlib import Path
 from fastapi import HTTPException
@@ -21,6 +22,30 @@ from .constants import KEYS, CLICK_BUTTONS, SCROLL_BUTTONS
 from .computer import *
 
 XDOTOOL_DELAY = 50
+
+
+def normalize_key(raw_key: str) -> str:
+    """Convert a supported client key expression to an xdotool key expression."""
+    if not raw_key or not raw_key.strip():
+        raise HTTPException(status_code=400, detail="Invalid key")
+
+    tokens = [token for token in raw_key.replace("+", " ").split() if token]
+    if not tokens:
+        raise HTTPException(status_code=400, detail="Invalid key")
+
+    normalized = []
+    for token in tokens:
+        key_name = token.lower()
+        if key_name in KEYS:
+            normalized.append(KEYS[key_name])
+        elif len(token) == 1 and token.isascii() and token.isalnum():
+            normalized.append(key_name)
+        else:
+            raise HTTPException(status_code=400, detail="Invalid key")
+
+    return "+".join(normalized)
+
+
 class XDOComputerTool(IComputerTool):
     def __init__(
             self,
@@ -110,15 +135,30 @@ class XDOComputerTool(IComputerTool):
 
     async def press_key(self, r: PressKeyRequest):
         self.logger.debug(f"press_key, {r}")
-        keys = [x for x in r.key.split(' ') if x]
-        if isinstance(keys, list):
-            key = "+".join(
-                KEYS[k.lower()] if k.lower() in KEYS else k.lower() for k in keys
+        key = normalize_key(r.key)
+        try:
+            process = await asyncio.create_subprocess_exec(
+                "xdotool",
+                "key",
+                "--",
+                key,
+                env={**os.environ, "DISPLAY": self._display},
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
             )
-        else:
-            key = KEYS[r.key.lower()] if r.key.lower() in KEYS else r.key.lower()
-        command_parts = [self._xdotool, f"key -- {key}"]
-        return await self.shell(" ".join(command_parts))
+        except FileNotFoundError as exc:
+            return BaseResult(output="", error=str(exc))
+
+        try:
+            stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=10)
+        except asyncio.TimeoutError as exc:
+            try:
+                process.kill()
+            except ProcessLookupError:
+                pass
+            raise TimeoutError("xdotool key command timed out after 10 seconds") from exc
+
+        return BaseResult(output=stdout.decode(), error=stderr.decode())
 
     async def type_text(self, r: TypeTextRequest):
         results: list[BaseResult] = []


### PR DESCRIPTION
## 背景

`tool_server` 的 `PressKey` 接口此前将请求参数 `Key` 拼接为 shell 命令，并通过 `create_subprocess_shell()` 执行；同时，`auth_key` 为空时会跳过鉴权。

该组合可能导致未授权调用及命令注入风险。

## 变更

- 强制要求配置非空 `auth_key`：
  - 服务启动时空值会直接失败。
  - 鉴权中间件不再因空配置放行请求。
  - 支持通过 `AUTH_KEY` 环境变量注入密钥。

- 修复 `PressKey` 命令注入：
  - 使用 `asyncio.create_subprocess_exec()` 参数化调用 `xdotool`。
  - 用户输入不再进入 shell。
  - `Key` 仅允许 `KEYS` 中定义的按键、单个字母/数字及合法组合键。
  - 支持如 `ctrl+c`、`alt+tab` 等组合键。
  - 非法 `Key` 返回 HTTP 400。

- 保留错误处理：
  - xdotool 不存在时返回错误结果。
  - 子进程超时时终止子进程并抛出超时错误。

- 更新配置和文档说明，明确 `auth_key` 必须配置。

## 验证

- `uv run python tests/test_presskey_security.py`
  - 6 个安全回归测试通过。
- `uv run python tests/test_startup_security.py`
  - 2 个启动鉴权测试通过。
- `AUTH_KEY=configured-secret uv run python -m compileall -q common middleware services tools main.py`
  - 编译检查通过。
- 验证 `AUTH_KEY` 配置可通过启动校验，空 `auth_key` 会被拒绝。