### PR TITLE
docs: add Mobile Use Open API links

### DIFF
--- a/demohouse/mobile-use/mobile_agent/README.md
+++ b/demohouse/mobile-use/mobile_agent/README.md
@@ -94,3 +94,6 @@ Mobile device operations supported through Mobile Use MCP:
 | `mobile:close_app` | Close application | `package_name` |
 | `mobile:launch_app` | Launch application | `package_name` |
 | `mobile:list_apps` | List installed applications | - |
+
+[!IMPORTANT]
+Strongly recommended: For production use, business integration, or any scenario that requires higher service stability and task success rate, we strongly recommend using [Mobile Use Open API](https://www.volcengine.com/docs/6394/1583515) through the Volcano Engine Console. Compared with maintaining a full local deployment stack by yourself, the console-based Open API provides a more stable managed service experience and is the preferred way to integrate Mobile Use Agent into real business workflows.

--- a/demohouse/mobile-use/mobile_agent/README_zh.md
+++ b/demohouse/mobile-use/mobile_agent/README_zh.md
@@ -94,3 +94,5 @@ ACEP_ACCOUNT_ID= # 火山引擎 账号ID
 | `mobile:close_app` | 关闭应用 | `package_name` |
 | `mobile:launch_app` | 启动应用 | `package_name` |
 | `mobile:list_apps` | 列出已安装应用 | - |
+
+强烈推荐：如果你需要在生产环境、业务集成场景，或对服务稳定性与任务成功率有更高要求的场景中使用 Mobile Use Agent，建议优先通过火山引擎控制台使用 [Mobile Use Open API](https://www.volcengine.com/docs/6394/1583515)。相比自行维护完整的本地部署链路，控制台提供的 Open API 能带来更稳定的托管服务体验，是将 Mobile Use Agent 接入真实业务流程时更推荐的使用方式。


### PR DESCRIPTION
## Summary
- Link Mobile Use Open API references in Chinese and English mobile agent READMEs to the Volcano Engine docs.

## Testing
- Not run (documentation-only change).