### PR TITLE
fix: migrate langchain shim imports to langchain_core

### DIFF
--- a/arkitect/core/component/llm/llm.py
+++ b/arkitect/core/component/llm/llm.py
@@ -14,8 +14,8 @@
 
 from typing import Any, Callable, Dict, List, Optional, Union
 
-from langchain.prompts.chat import BaseChatPromptTemplate
-from langchain.schema.output_parser import BaseTransformOutputParser
+from langchain_core.output_parsers import BaseTransformOutputParser
+from langchain_core.prompts.chat import BaseChatPromptTemplate
 from volcenginesdkarkruntime import Ark, AsyncArk
 from volcenginesdkarkruntime._streaming import AsyncStream, Stream
 from volcenginesdkarkruntime.types.chat import (

--- a/arkitect/core/component/llm/utils.py
+++ b/arkitect/core/component/llm/utils.py
@@ -16,7 +16,6 @@ import json
 import logging
 from typing import Any, Dict, List, Set, Union
 
-from langchain.prompts.chat import BaseChatPromptTemplate
 from langchain_core.messages import (
     AIMessage,
     BaseMessage,
@@ -25,18 +24,19 @@ from langchain_core.messages import (
     SystemMessage,
 )
 from langchain_core.messages.tool import ToolCall
+from langchain_core.prompts.chat import BaseChatPromptTemplate
 from typing_extensions import Literal
 from volcenginesdkarkruntime.types.chat import ChatCompletionMessage
 from volcenginesdkarkruntime.types.chat.chat_completion_chunk import ChoiceDelta
 
 from arkitect.core.errors import InvalidParameter
+from arkitect.core.utils.converter import to_dict
 from arkitect.telemetry.trace import task
 from arkitect.types.llm.model import (
     ArkMessage,
     ChatCompletionMessageToolCallParam,
     Function,
 )
-from arkitect.core.utils.converter import to_dict
 
 
 def _convert_message_role_to_ark_role(  # type: ignore

--- a/arkitect/core/component/prompts/custom_prompt.py
+++ b/arkitect/core/component/prompts/custom_prompt.py
@@ -21,14 +21,14 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import jinja2
 import pytz
 from jinja2 import Template
-from langchain.prompts.chat import BaseChatPromptTemplate
-from langchain.schema.messages import (
+from langchain_core.messages import (
     AIMessage,
     BaseMessage,
     HumanMessage,
     SystemMessage,
     get_buffer_string,
 )
+from langchain_core.prompts.chat import BaseChatPromptTemplate
 from pydantic.v1 import validator
 
 from arkitect.types.llm.model import ArkChatRequest

--- a/demohouse/live_voice_call/backend/prompt.py
+++ b/demohouse/live_voice_call/backend/prompt.py
@@ -11,8 +11,8 @@
 
 from typing import Any, List
 
-from langchain.prompts.chat import BaseChatPromptTemplate
 from langchain_core.messages import AnyMessage, BaseMessage, SystemMessage
+from langchain_core.prompts.chat import BaseChatPromptTemplate
 
 SYSTEM_PROMPT = """
 # 角色任务


### PR DESCRIPTION
Fixes #226

## What changed

After the langchain 1.x restructure removed its re-export shims, `from langchain.prompts.chat import ...` / `from langchain.schema... import ...` break with `ModuleNotFoundError: No module named 'langchain.prompts'`. This migrates the affected imports to `langchain_core`, which is already a declared dependency (`pyproject.toml`) and already used elsewhere in the codebase (`arkitect/core/component/llm/base.py`, `arkitect/core/component/output_parser/rag_output.py`).

- `arkitect/core/component/prompts/custom_prompt.py` — `langchain.prompts.chat` → `langchain_core.prompts.chat`, `langchain.schema.messages` → `langchain_core.messages`
- `arkitect/core/component/llm/llm.py` — `langchain.prompts.chat` → `langchain_core.prompts.chat`, `langchain.schema.output_parser` → `langchain_core.output_parsers`
- `arkitect/core/component/llm/utils.py` — `langchain.prompts.chat` → `langchain_core.prompts.chat`
- `demohouse/live_voice_call/backend/prompt.py` — `langchain.prompts.chat` → `langchain_core.prompts.chat`

## How verified

- `py_compile` on all four files
- Import smoke test after `uv sync`: all four modules import cleanly
- `ruff check --select I` clean on the touched files (the remaining E501 warnings are pre-existing on main)
